### PR TITLE
handle empty pagination url

### DIFF
--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -651,7 +651,7 @@ module Coinbase
         http_verb('GET', uri, nil, headers) do |resp|
           if params[:fetch_all] == true &&
             resp.body.has_key?('pagination') &&
-            resp.body['pagination']['next_uri'] != nil
+            !resp.body['pagination']['next_uri'].to_s.empty?
               params[:starting_after] = resp.body['data'].last['id']
               get(path, params) do |page|
                 body = resp.body

--- a/lib/coinbase/wallet/api_response.rb
+++ b/lib/coinbase/wallet/api_response.rb
@@ -34,7 +34,7 @@ module Coinbase
       end
 
       def has_more?
-        body.has_key?('pagination') && body['pagination']['next_uri'] != nil
+        body.has_key?('pagination') && !body['pagination']['next_uri'].to_s.empty?
       end
     end
   end


### PR DESCRIPTION
Coinbase api suddenly started sending the following response when no pagination available.

```
{"data"=>[],
 "pagination"=>{"ending_before"=>"", "limit"=>0, "next_starting_after"=>"", "next_uri"=>"", "order"=>"", "previous_ending_before"=>"", "previous_uri"=>"", "starting_after"=>""}}
```